### PR TITLE
7 implement http and ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ shop/prestashop/
 /.vscode/
 **/venv/
 **/__pycache__/
+*.key
+*.crt

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/mariadb/
-/prestashop/
+shop/mariadb/
+shop/prestashop/
 /.vscode/
 **/venv/
 **/__pycache__/

--- a/shop/Dockerfile
+++ b/shop/Dockerfile
@@ -1,0 +1,8 @@
+FROM prestashop/prestashop:1.7.8.10-apache
+
+COPY ./prestashop.crt /etc/ssl/certs/prestashop.crt
+COPY ./prestashop.key /etc/ssl/private/prestashop.key
+COPY ./prestashop.crt /usr/local/share/ca-certificates/prestashop.crt
+COPY ./prestashop-ssl.conf /etc/apache2/sites-enabled/prestashop-ssl.conf
+
+RUN update-ca-certificates && a2enmod ssl && a2ensite prestashop-ssl.conf

--- a/shop/Dockerfile
+++ b/shop/Dockerfile
@@ -1,8 +1,0 @@
-FROM prestashop/prestashop:1.7.8.10-apache
-
-COPY ./prestashop.crt /etc/ssl/certs/prestashop.crt
-COPY ./prestashop.key /etc/ssl/private/prestashop.key
-COPY ./prestashop.crt /usr/local/share/ca-certificates/prestashop.crt
-COPY ./prestashop-ssl.conf /etc/apache2/sites-enabled/prestashop-ssl.conf
-
-RUN update-ca-certificates && a2enmod ssl && a2ensite prestashop-ssl.conf

--- a/shop/README.md
+++ b/shop/README.md
@@ -48,9 +48,11 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout prestashop.key -out 
 docker-compose up -d
 ```
 
-4. W przeglądarce sieciowej wchodzimy na adres https://localhost:8081
+4. W przeglądarce sieciowej wchodzimy na adres https://localhost
 
-5. Aby zatrzymać działanie kontenerów:
+5. Przy pierwszym uruchomieniu będziemy musieli zaakceptować certyfikat
+
+6. Aby zatrzymać działanie kontenerów:
 ```c++
 docker-compose down
 ```

--- a/shop/README.md
+++ b/shop/README.md
@@ -40,7 +40,7 @@ jak się zainstaluje zmienamy nazwę folderu admin na dowolną inną np admin1 i
 
 2. Generujemy certyfikat ssl:
 ```c++
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout prestshop.key -out prestashop.crt -subj "/C=PL/ST=Pomeranian Voivodeship/L=Gdansk/O=Donice Hermiony/OU=Donice Hermiony/CN=localhost"
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout prestashop.key -out prestashop.crt -subj "/C=PL/ST=Pomeranian Voivodeship/L=Gdansk/O=Donice Hermiony/OU=Donice Hermiony/CN=localhost"
 ```
 
 3. Uruchamiamy kontenery za pomocą:

--- a/shop/README.md
+++ b/shop/README.md
@@ -33,3 +33,24 @@ user `root`,
 haslo `admin`
 
 jak się zainstaluje zmienamy nazwę folderu admin na dowolną inną np admin1 i usuwamy folder `install`. Oba są w `prestashop/src/`.
+
+## Uruchomienie sklepu
+
+1. Wchodzimy do folderu `shop`
+
+2. Generujemy certyfikat ssl:
+```c++
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout prestshop.key -out prestashop.crt -subj "/C=PL/ST=Pomeranian Voivodeship/L=Gdansk/O=Donice Hermiony/OU=Donice Hermiony/CN=localhost"
+```
+
+3. Uruchamiamy kontenery za pomocą:
+```c++
+docker-compose up -d
+```
+
+4. W przeglądarce sieciowej wchodzimy na adres https://localhost:8081
+
+5. Aby zatrzymać działanie kontenerów:
+```c++
+docker-compose down
+```

--- a/shop/docker-compose.yml
+++ b/shop/docker-compose.yml
@@ -8,27 +8,24 @@ services:
       MYSQL_ROOT_PASSWORD: admin
       MYSQL_DATABASE: prestashop
     volumes:
-      - ./mariadb/db_dump:/docker-entrypoint-initdb.d
+      - ./db_dump:/docker-entrypoint-initdb.d
       - ./mariadb:/var/lib/mysql
 
   prestashop:
     container_name: prestashop
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: prestashop/prestashop:1.7.8.10-apache
     restart: always
     depends_on:
       - mariadb
     ports:
       - 443:443
-      - 8080:80
+      - 8080:443
     environment:
       DB_SERVER: presta-mariadb
       DB_NAME: prestashop
       DB_USER: root
       DB_PASSWD: admin
       PS_INSTALL_AUTO: 0
-      PS_DOMAIN: localhost:8080
       PS_FOLDER_ADMIN: admin
       PS_FOLDER_INSTALL: install  
       PS_LANGUAGE: pl
@@ -36,3 +33,15 @@ services:
       PS_DEV_MODE: 1
     volumes:
       - ./prestashop/src:/var/www/html
+      - ./prestashop.crt:/etc/ssl/certs/prestashop.crt
+      - ./prestashop.key:/etc/ssl/private/prestashop.key
+      - ./prestashop_ssl.conf:/etc/apache2/sites-available/prestashop_ssl.conf
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        cp /etc/ssl/certs/prestashop.crt /usr/local/share/ca-certificates/prestashop.crt
+        update-ca-certificates
+        a2ensite prestashop_ssl
+        a2enmod ssl
+        apache2-foreground

--- a/shop/docker-compose.yml
+++ b/shop/docker-compose.yml
@@ -13,11 +13,14 @@ services:
 
   prestashop:
     container_name: prestashop
-    image: prestashop/prestashop:1.7.8.10-apache
+    build:
+      context: .
+      dockerfile: Dockerfile
     restart: always
     depends_on:
       - mariadb
     ports:
+      - 443:443
       - 8080:80
     environment:
       DB_SERVER: presta-mariadb

--- a/shop/prestashop_ssl.conf
+++ b/shop/prestashop_ssl.conf
@@ -1,0 +1,11 @@
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/prestashop.crt
+    SSLCertificationKeyFile /etc/ssl/private/prestashop.key
+    SSLProtocol all +TLSv1.2 +TLSv1.3
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ServerName localhost
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/shop/prestashop_ssl.conf
+++ b/shop/prestashop_ssl.conf
@@ -1,8 +1,8 @@
 <VirtualHost *:443>
     SSLEngine on
     SSLCertificateFile /etc/ssl/certs/prestashop.crt
-    SSLCertificationKeyFile /etc/ssl/private/prestashop.key
-    SSLProtocol all +TLSv1.2 +TLSv1.3
+    SSLCertificateKeyFile /etc/ssl/private/prestashop.key
+    SSLProtocol -all +TLSv1.2 +TLSv1.3
     ServerAdmin webmaster@localhost
     DocumentRoot /var/www/html
     ServerName localhost


### PR DESCRIPTION
Prestashop is configured for https access. Before launching the website po the first time after updating your local repository, you should create your own key and certificate with command given in readme file.
Also please use updated docker-compose file to properly launch new our webshop.